### PR TITLE
Replaced the C-style for statements with Swift ranges

### DIFF
--- a/Calendar/CalendarKit/CalendarLogic.swift
+++ b/Calendar/CalendarKit/CalendarLogic.swift
@@ -92,7 +92,7 @@ class CalendarLogic: Hashable {
         var dates = [Date]()
         let numberOfDaysInMonth = baseDate.numberOfDaysInMonth
         let component = baseDate.monthDayAndYearComponents
-        for var i = 1; i <= numberOfDaysInMonth; i++ {
+        for i in 1 ... numberOfDaysInMonth {
             dates.append(Date(day: i, month: component.month, year: component.year))
         }
         return dates
@@ -107,8 +107,11 @@ class CalendarLogic: Hashable {
         let numberOfVisibleDays = numberOfDaysInPreviousPartialWeek
         let parts = date.monthDayAndYearComponents
         
-        for var i = numberOfDaysInMonth - (numberOfVisibleDays - 1); i <= numberOfDaysInMonth; i++ {
-            dates.append(Date(day: i, month: parts.month, year: parts.year))
+        for i in (numberOfDaysInMonth - (numberOfVisibleDays - 1)) ... numberOfDaysInMonth {
+            // If 'numberOfVisibleDays' is equal to 0, the range fails, because -(-1) makes the start > end
+            if (numberOfDaysInMonth - (numberOfVisibleDays - 1)) < numberOfDaysInMonth {
+                dates.append(Date(day: i, month: parts.month, year: parts.year))
+            }
         }
         return dates
     }
@@ -120,7 +123,7 @@ class CalendarLogic: Hashable {
         let numberOfDays = numberOfVisibleDaysforFollowingMonth
         let parts  = date.monthDayAndYearComponents
         
-        for var i = 1; i <= numberOfDays; i++ {
+        for i in 1 ... numberOfDays {
             dates.append(Date(day: i, month: parts.month, year: parts.year))
         }
         return dates

--- a/Calendar/CalendarKit/CalendarLogic.swift
+++ b/Calendar/CalendarKit/CalendarLogic.swift
@@ -107,12 +107,13 @@ class CalendarLogic: Hashable {
         let numberOfVisibleDays = numberOfDaysInPreviousPartialWeek
         let parts = date.monthDayAndYearComponents
         
-        for i in (numberOfDaysInMonth - (numberOfVisibleDays - 1)) ... numberOfDaysInMonth {
-            // If 'numberOfVisibleDays' is equal to 0, the range fails, because -(-1) makes the start > end
-            if (numberOfDaysInMonth - (numberOfVisibleDays - 1)) < numberOfDaysInMonth {
+        // If 'numberOfVisibleDays' is equal to 0, the range fails, because -(-1) makes the start > end
+        if (numberOfDaysInMonth - (numberOfVisibleDays - 1)) < numberOfDaysInMonth {
+            for i in (numberOfDaysInMonth - (numberOfVisibleDays - 1)) ... numberOfDaysInMonth {
                 dates.append(Date(day: i, month: parts.month, year: parts.year))
             }
         }
+        
         return dates
     }
 

--- a/Calendar/CalendarKit/CalendarView.swift
+++ b/Calendar/CalendarKit/CalendarView.swift
@@ -32,7 +32,7 @@ class CalendarView: UIView, UICollectionViewDataSource, UICollectionViewDelegate
                 var set = Set<CalendarLogic>()
                 set.insert(CalendarLogic(date: baseDate!))
                 // advance one year
-                for var i = 0; i < kMonthRange; i++ {
+                for _ in 0 ..< kMonthRange {
                     dateIter1 = dateIter1.firstDayOfFollowingMonth
                     dateIter2 = dateIter2.firstDayOfPreviousMonth
                     
@@ -138,7 +138,7 @@ class CalendarView: UIView, UICollectionViewDataSource, UICollectionViewDelegate
     
     func moveToSelectedDate(animated: Bool) {
         var index = -1
-        for var i = 0; i < collectionData.count; i++  {
+        for i in 0 ..< collectionData.count {
             let logic = collectionData[i]
             if logic.containsDate(selectedDate!) {
                 index = i

--- a/Calendar/CalendarKit/WeekHeaderView.swift
+++ b/Calendar/CalendarKit/WeekHeaderView.swift
@@ -16,7 +16,7 @@ class WeekHeaderView: UICollectionReusableView {
     
     override func awakeFromNib() {
         if labels.count == formatter.weekdaySymbols.count {
-            for var i = 0; i < formatter.weekdaySymbols.count; i++ {
+            for i in 0 ..< formatter.weekdaySymbols.count {
                 let weekDayString = formatter.weekdaySymbols[i] 
                 
                 labels[i].text = weekDayString.substringToIndex(weekDayString.startIndex.advancedBy(3)).uppercaseString


### PR DESCRIPTION
To avoid the deprecation warnings in Swift 2.1.1 (and possible crashes in Swift 3.0)
